### PR TITLE
Hack to fix compartibility with TC4.1

### DIFF
--- a/main/java/net/ixios/advancedthaumaturgy/items/ItemMercurialWand.java
+++ b/main/java/net/ixios/advancedthaumaturgy/items/ItemMercurialWand.java
@@ -44,10 +44,10 @@ import thaumcraft.common.items.wands.WandManager;
 import thaumcraft.common.lib.research.ResearchManager;
 import thaumcraft.common.tiles.TileInfusionMatrix;
 
-public class ItemMercurialWand extends ItemWandCasting implements IVisDiscountGear
+public class ItemMercurialWand extends ItemWandCasting 
 {
 
-	private DecimalFormat myFormatter;
+    private DecimalFormat myFormatter;
     private boolean classictooltip = false;
     private ItemMercUpgrades upgrades = ItemMercUpgrades.None;
     
@@ -196,11 +196,6 @@ public class ItemMercurialWand extends ItemWandCasting implements IVisDiscountGe
     	return (super.getConsumptionModifier(stack, player, aspect) - discount);
     }
     
-    
-    public int getVisDiscount(ItemStack stack, EntityPlayer player, Aspect aspect)
-    {
-        return (1 - cap.getBaseCostModifier());
-    }
     
     @SuppressWarnings({ "unchecked", "rawtypes" })
 	@Override

--- a/main/java/net/ixios/advancedthaumaturgy/items/ItemMercurialWand.java
+++ b/main/java/net/ixios/advancedthaumaturgy/items/ItemMercurialWand.java
@@ -44,7 +44,7 @@ import thaumcraft.common.items.wands.WandManager;
 import thaumcraft.common.lib.research.ResearchManager;
 import thaumcraft.common.tiles.TileInfusionMatrix;
 
-public class ItemMercurialWand extends ItemWandCasting
+public class ItemMercurialWand extends ItemWandCasting implements IVisDiscountGear
 {
 
 	private DecimalFormat myFormatter;
@@ -196,6 +196,12 @@ public class ItemMercurialWand extends ItemWandCasting
     	return (super.getConsumptionModifier(stack, player, aspect) - discount);
     }
     
+    
+    public int getVisDiscount(ItemStack stack, EntityPlayer player, Aspect aspect)
+    {
+        return (1 - cap.getBaseCostModifier());
+    }
+    
     @SuppressWarnings({ "unchecked", "rawtypes" })
 	@Override
     public void addInformation(ItemStack stack, EntityPlayer player, List list, boolean detailed)
@@ -203,11 +209,11 @@ public class ItemMercurialWand extends ItemWandCasting
     	AspectList vis = this.getAllVis(stack);
     	StringBuilder result = new StringBuilder();
     	result.append("\u00a7r");
-    	float discount = WandManager.getTotalVisDiscount(player);
+    	//float discount = WandManager.getTotalVisDiscount(player);
     	boolean shiftdown = Keyboard.isKeyDown(Keyboard.KEY_LSHIFT) || Keyboard.isKeyDown(Keyboard.KEY_RSHIFT);
     	WandCap cap = getCap(stack);
     	
-    	discount += (1 - (cap.getBaseCostModifier()));
+    	//discount += (1 - (cap.getBaseCostModifier()));
     	
     	if (classictooltip && !shiftdown)
     	{
@@ -226,7 +232,7 @@ public class ItemMercurialWand extends ItemWandCasting
 	    	result.setLength(result.length() - 2);
 	    	
 	    	list.add(result.toString());
-	    	list.add("Vis discount: " + (int)(discount * 100) + "% total");
+	    	//list.add("Vis discount: " + (int)(discount * 100) + "% total");
     	}
     	
     	if (upgrades != ItemMercUpgrades.None)

--- a/main/java/net/ixios/advancedthaumaturgy/items/ItemMercurialWand.java
+++ b/main/java/net/ixios/advancedthaumaturgy/items/ItemMercurialWand.java
@@ -44,7 +44,7 @@ import thaumcraft.common.items.wands.WandManager;
 import thaumcraft.common.lib.research.ResearchManager;
 import thaumcraft.common.tiles.TileInfusionMatrix;
 
-public class ItemMercurialWand extends ItemWandCasting 
+public class ItemMercurialWand extends ItemWandCasting
 {
 
     private DecimalFormat myFormatter;


### PR DESCRIPTION
I've removed the code to display total vis discount on the mercurial wand. The vis discount can be different for different aspects, and the tooltip is already big enough to add five more discounts.
